### PR TITLE
Update component_templates.cwt

### DIFF
--- a/config/component_templates.cwt
+++ b/config/component_templates.cwt
@@ -48,7 +48,6 @@ component_template = {
 	## cardinality = 0..1
 	## replace_scope = { root = country this = country }
  	valid_for_country = { 		 		
- 		factor = float
 		alias_name[modifier_rule] = alias_match_left[modifier_rule]
  	}
 	## cardinality = 0..1


### PR DESCRIPTION
another correction, screwed this one up. Here is a usage example base on 1.9 vanilla (this still works, 100% verified):

	valid_for_country = {
		modifier = {
			factor = 0
			is_country_type = default
		}
	}