### PR TITLE
Update components_sets.cwt

### DIFF
--- a/config/components_sets.cwt
+++ b/config/components_sets.cwt
@@ -10,14 +10,18 @@ types = {
 }
 
 component_set = {
-	icon = <sprite>
-	icon_frame = int
 	## cardinality = 0..1
 	required_component_set = bool
 	subtype[required_component] = {
 		key = scalar
+		## cardinality = 0..1
+		icon = scalar
+		## cardinality = 0..1
+		icon_frame = scalar		
 	}
 	subtype[!required_component] = {
 		key = localisation
+		icon = <sprite>
+		icon_frame = int		
 	}
 }


### PR DESCRIPTION
the gfx for required components is not displayed in game at all. The gfx defined for these in vanilla is just relics that point to non-existing gfx entries. I made it scalar so it stops throwing errors.