### PR TITLE
Added traits to ruler scope

### DIFF
--- a/config/prescripted_countries/prescripted_countries.cwt
+++ b/config/prescripted_countries/prescripted_countries.cwt
@@ -123,7 +123,8 @@ prescripted_country = {
 		
 		## cardinality = 0..1
 		leader_class = enum[leader_classes]
-
+		## cardinality = 0..inf
+	    trait = <trait.leader_trait>
 	}
 
 	## cardinality = 0..1


### PR DESCRIPTION
the trait effect allows adding traits to the initial ruler, up to the maximum allowed by the engine/configuration, which in vanilla is 2, but leaving it open as it does not produce an error if more traits are defined.